### PR TITLE
#7 - Move code for jdi-http-cucumber to jdi-dark repository

### DIFF
--- a/jdi-dark-bdd-tests/pom.xml
+++ b/jdi-dark-bdd-tests/pom.xml
@@ -11,30 +11,42 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <allure.version>1.4.23</allure.version>
-        <aspectj.version>1.8.5</aspectj.version>
+        <aspectj.version>1.9.1</aspectj.version>
         <cucumber.version>1.2.5</cucumber.version>
+        <allure.maven>2.9</allure.maven>
+        <allure.cucumber.jvm>2.12.1</allure.cucumber.jvm>
     </properties>
 
     <dependencies>
         <!--JDI-->
         <dependency>
             <groupId>com.epam.jdi</groupId>
-            <artifactId>jdi-http</artifactId>
-            <version>1.1.34</version>
+            <artifactId>jdi-dark-bdd</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
-            <groupId>com.epam.jdi</groupId>
-            <artifactId>jdi-http-cucumber</artifactId>
-            <version>1.1.34</version>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-cucumber-jvm</artifactId>
+            <version>${allure.cucumber.jvm}</version>
         </dependency>
+<!--        &lt;!&ndash;JDI&ndash;&gt;-->
+<!--        <dependency>-->
+<!--            <groupId>com.epam.jdi</groupId>-->
+<!--            <artifactId>jdi-http</artifactId>-->
+<!--            <version>1.1.34</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>com.epam.jdi</groupId>-->
+<!--            <artifactId>jdi-http-cucumber</artifactId>-->
+<!--            <version>1.1.34</version>-->
+<!--        </dependency>-->
 
-        <!--Allure-->
-        <dependency>
-            <groupId>ru.yandex.qatools.allure</groupId>
-            <artifactId>allure-testng-adaptor</artifactId>
-            <version>RELEASE</version>
-        </dependency>
+<!--        &lt;!&ndash;Allure&ndash;&gt;-->
+<!--        <dependency>-->
+<!--            <groupId>ru.yandex.qatools.allure</groupId>-->
+<!--            <artifactId>allure-testng-adaptor</artifactId>-->
+<!--            <version>RELEASE</version>-->
+<!--        </dependency>-->
 
         <!--CucumberTestNG-->
         <dependency>
@@ -80,28 +92,28 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>ru.yandex.qatools.allure</groupId>
-                <artifactId>allure-maven-plugin</artifactId>
-                <version>2.5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <phase>post-integration-test</phase>
-                    </execution>
-                </executions>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>${allure.maven}</version>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <reporting>
         <excludeDefaults>true</excludeDefaults>
         <plugins>
             <plugin>
-                <groupId>ru.yandex.qatools.allure</groupId>
-                <artifactId>allure-maven-plugin</artifactId>
-                <version>RELEASE</version>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
             </plugin>
         </plugins>
     </reporting>

--- a/jdi-dark-bdd-tests/pom.xml
+++ b/jdi-dark-bdd-tests/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.epam.jdi</groupId>
+    <artifactId>jdi-dark-bdd-tests</artifactId>
+    <name>EPAM JDI HTTP Cucumber Tests</name>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <allure.version>1.4.23</allure.version>
+        <aspectj.version>1.8.5</aspectj.version>
+        <cucumber.version>1.2.5</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <!--JDI-->
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-http</artifactId>
+            <version>1.1.34</version>
+        </dependency>
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-http-cucumber</artifactId>
+            <version>1.1.34</version>
+        </dependency>
+
+        <!--Allure-->
+        <dependency>
+            <groupId>ru.yandex.qatools.allure</groupId>
+            <artifactId>allure-testng-adaptor</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+
+        <!--CucumberTestNG-->
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-testng</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+
+        <!--CucumberJava-->
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <properties>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>true</value>
+                            <!-- disabling default listeners is optional -->
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>ru.yandex.qatools.allure</groupId>
+                <artifactId>allure-maven-plugin</artifactId>
+                <version>2.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>post-integration-test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>ru.yandex.qatools.allure</groupId>
+                <artifactId>allure-maven-plugin</artifactId>
+                <version>RELEASE</version>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/jdi-dark-bdd-tests/src/main/java/com/epam/jdi/httptests/ServiceExample.java
+++ b/jdi-dark-bdd-tests/src/main/java/com/epam/jdi/httptests/ServiceExample.java
@@ -1,0 +1,55 @@
+package com.epam.jdi.httptests;
+
+import com.epam.http.annotations.*;
+import com.epam.http.requests.RestMethod;
+import com.epam.jdi.http.cucumber.IRestService;
+
+import static io.restassured.http.ContentType.JSON;
+
+@ServiceDomain("http://httpbin.org/")
+public class ServiceExample implements IRestService {
+    @ContentType(JSON)
+    @GET("/get")
+    @Headers({
+            @Header(name = "Name", value = "Roman"),
+            @Header(name = "Id", value = "Test")
+    })
+    static RestMethod getMethod;
+
+    @Header(name = "Type", value = "Test")
+    @POST("/post")
+    RestMethod postMethod;
+
+    @PUT("/put")
+    RestMethod putMethod;
+    @PATCH("/patch")
+    RestMethod patch;
+    @DELETE("/delete")
+    RestMethod delete;
+    @GET("/status/%s")
+    RestMethod status;
+
+    public RestMethod getGetMethod() {
+        return getMethod;
+    }
+
+    public RestMethod getPostMethod() {
+        return postMethod;
+    }
+
+    public RestMethod getPutMethod() {
+        return putMethod;
+    }
+
+    public RestMethod getPatch() {
+        return patch;
+    }
+
+    public RestMethod getDelete() {
+        return delete;
+    }
+
+    public RestMethod getStatus() {
+        return status;
+    }
+}

--- a/jdi-dark-bdd-tests/src/main/java/com/epam/jdi/httptests/ServiceExample.java
+++ b/jdi-dark-bdd-tests/src/main/java/com/epam/jdi/httptests/ServiceExample.java
@@ -2,7 +2,7 @@ package com.epam.jdi.httptests;
 
 import com.epam.http.annotations.*;
 import com.epam.http.requests.RestMethod;
-import com.epam.jdi.http.cucumber.IRestService;
+import com.epam.jdi.http.IRestService;
 
 import static io.restassured.http.ContentType.JSON;
 

--- a/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/HttpTestsRunner.java
+++ b/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/HttpTestsRunner.java
@@ -1,0 +1,9 @@
+package com.epam.jdi.httptests;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(features = "src/test/resources/features/",
+        glue = {"com/epam/jdi/httptests/steps", "com/epam/jdi/http/stepdefs/en"})
+public class HttpTestsRunner extends AbstractTestNGCucumberTests {
+}

--- a/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/steps/InitService.java
+++ b/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/steps/InitService.java
@@ -1,0 +1,15 @@
+package com.epam.jdi.httptests.steps;
+
+import com.epam.jdi.httptests.ServiceExample;
+import cucumber.api.java.en.Given;
+
+import static com.epam.http.requests.ServiceInit.init;
+import static com.epam.jdi.http.cucumber.Utils.*;
+
+public class InitService {
+    @Given("^I init service$")
+    public void initService() {
+        domainUrl.set(getDomain(ServiceExample.class));
+        service.set(init(ServiceExample.class));
+    }
+}

--- a/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/steps/InitService.java
+++ b/jdi-dark-bdd-tests/src/test/java/com/epam/jdi/httptests/steps/InitService.java
@@ -4,7 +4,7 @@ import com.epam.jdi.httptests.ServiceExample;
 import cucumber.api.java.en.Given;
 
 import static com.epam.http.requests.ServiceInit.init;
-import static com.epam.jdi.http.cucumber.Utils.*;
+import static com.epam.jdi.http.Utils.*;
 
 public class InitService {
     @Given("^I init service$")

--- a/jdi-dark-bdd-tests/src/test/resources/features/GetAndPost.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/GetAndPost.feature
@@ -5,10 +5,9 @@ Feature: GET and POST check
     When I do <method> request
     Then Response status type is <responseStatus>
     And Response body has values
-      | url         | <url>         |
-      | headers.Host| httpbin.org |
-
-  Examples:
-    | method | responseStatus | url                     |
-    | get    | OK             | http://httpbin.org/get  |
-    | post   | OK             | http://httpbin.org/post |
+      | url          | <url>       |
+      | headers.Host | httpbin.org |
+    Examples:
+      | method | responseStatus | url                      |
+      | get    | OK             | https://httpbin.org/get  |
+      | post   | OK             | https://httpbin.org/post |

--- a/jdi-dark-bdd-tests/src/test/resources/features/GetAndPost.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/GetAndPost.feature
@@ -1,0 +1,14 @@
+Feature: GET and POST check
+
+  Scenario Outline: Check response
+    Given I init service
+    When I do <method> request
+    Then Response status type is <responseStatus>
+    And Response body has values
+      | url         | <url>         |
+      | headers.Host| httpbin.org |
+
+  Examples:
+    | method | responseStatus | url                     |
+    | get    | OK             | http://httpbin.org/get  |
+    | post   | OK             | http://httpbin.org/post |

--- a/jdi-dark-bdd-tests/src/test/resources/features/JsonResponse.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/JsonResponse.feature
@@ -1,0 +1,11 @@
+Feature: Json response check
+
+  Scenario: Check json response
+    Given I init service
+    And I set JSON request content type
+    When I do get request
+    Then Response status type is OK
+    And Response body has values
+      |url         |http://httpbin.org/get|
+      |headers.Host|httpbin.org           |
+    And Response header "Connection" is "keep-alive"

--- a/jdi-dark-bdd-tests/src/test/resources/features/JsonResponse.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/JsonResponse.feature
@@ -6,6 +6,6 @@ Feature: Json response check
     When I do get request
     Then Response status type is OK
     And Response body has values
-      |url         |http://httpbin.org/get|
-      |headers.Host|httpbin.org           |
+      | url          | https://httpbin.org/get |
+      | headers.Host | httpbin.org             |
     And Response header "Connection" is "keep-alive"

--- a/jdi-dark-bdd-tests/src/test/resources/features/LoadService.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/LoadService.feature
@@ -1,0 +1,8 @@
+Feature: Performance after load check
+
+  Scenario: Load service
+    Given I init service
+    When I load service for 20 sec with get requests
+    Then I check number of requests
+    And I check if performance results contain any fails
+    And Average response time is lesser than 2 sec

--- a/jdi-dark-bdd-tests/src/test/resources/features/RequestHeaders.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/RequestHeaders.feature
@@ -1,0 +1,12 @@
+Feature: Request headers check
+
+  Scenario: Pass headers and check response
+    Given I init service
+    When I have the following headers:
+      | Name       | Katarina |
+      | Id         | 1        |
+    And I do get request
+    And I print response
+    Then Response status type is OK
+    And Response "headers.Name" is "Katarina"
+    And Response "headers.Id" is "1"

--- a/jdi-dark-bdd-tests/src/test/resources/features/ResponseStatus.feature
+++ b/jdi-dark-bdd-tests/src/test/resources/features/ResponseStatus.feature
@@ -1,0 +1,8 @@
+Feature: Response status check
+
+  Scenario: Server error status request
+    Given I init service
+    When I do status request with 503 code
+    Then Response status code equals 503
+    And Response status type is SERVER_ERROR
+    And Response body is empty

--- a/jdi-dark-bdd-tests/src/test/resources/log4j.properties
+++ b/jdi-dark-bdd-tests/src/test/resources/log4j.properties
@@ -1,0 +1,34 @@
+log4j.rootLogger = info, console
+  #, file, HTML
+
+# ************************************************************************
+# Log level/appender definitions
+# ************************************************************************
+
+
+log4j.appender.console = org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout = org.apache.log4j.PatternLayout
+#log4j.appender.console.layout.ConversionPattern = [%p](%c) %m%n
+log4j.appender.console.layout.ConversionPattern = %m%n
+
+#log4j.appender.file=org.apache.log4j.RollingFileAppender
+##log4j.appender.file.File=target/.logs/events-%d{MM-dd-yy-HH-mm-ss}.log
+#log4j.appender.file.File=target/.logs/events.log
+#log4j.appender.file.layout=org.apache.log4j.PatternLayout
+#log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+#
+#log4j.appender.HTML = org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.HTML.File = target/.logs/events.html
+#log4j.appender.HTML.MaxFileSize=200MB
+#log4j.appender.HTML.layout = org.apache.log4j.HTMLLayout
+#log4j.appender.HTML.Append=false
+
+#log4j.appender.dailylog = org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.dailylog.File = test.log
+#log4j.appender.dailylog.DatePattern = '.'yyyy-MM-dd
+#log4j.appender.dailylog.layout = org.apache.log4j.PatternLayout
+#log4j.appender.dailylog.layout.ConversionPattern = [%d] [%-5p] - (%-22c) %m%n
+
+# ************************************************************************
+# END 
+# ************************************************************************

--- a/jdi-dark-bdd/pom.xml
+++ b/jdi-dark-bdd/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.epam.jdi</groupId>
+    <artifactId>jdi-dark-bdd</artifactId>
+    <name>EPAM JDI HTTP Cucumber</name>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>3.141.59</version>
+        </dependency>
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-http</artifactId>
+            <version>1.1.34</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.yandex.qatools.allure</groupId>
+            <artifactId>allure-testng-adaptor</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-testng</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.10</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <properties>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>true</value>
+                            <!-- disabling default listeners is optional -->
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+</project>

--- a/jdi-dark-bdd/pom.xml
+++ b/jdi-dark-bdd/pom.xml
@@ -7,35 +7,24 @@
     <groupId>com.epam.jdi</groupId>
     <artifactId>jdi-dark-bdd</artifactId>
     <name>EPAM JDI HTTP Cucumber</name>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
 
     <dependencies>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
-        </dependency>
+        <!--JDI-->
         <dependency>
             <groupId>com.epam.jdi</groupId>
-            <artifactId>jdi-http</artifactId>
-            <version>1.1.34</version>
-        </dependency>
-        <dependency>
-            <groupId>ru.yandex.qatools.allure</groupId>
-            <artifactId>allure-testng-adaptor</artifactId>
-            <version>RELEASE</version>
+            <artifactId>jdi-dark</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-testng</artifactId>
             <version>RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
             <version>RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
@@ -45,6 +34,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <version>RELEASE</version>
         </dependency>
     </dependencies>
@@ -62,33 +56,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.10</version>
-                <configuration>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                    <properties>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>true</value>
-                            <!-- disabling default listeners is optional -->
-                        </property>
-                    </properties>
-                </configuration>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
 
 </project>

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/IRestService.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/IRestService.java
@@ -1,0 +1,17 @@
+package com.epam.jdi.http;
+
+import com.epam.http.requests.RestMethod;
+
+public interface IRestService {
+    RestMethod getGetMethod();
+
+    RestMethod getPostMethod();
+
+    RestMethod getPutMethod();
+
+    RestMethod getPatch();
+
+    RestMethod getDelete();
+
+    RestMethod getStatus();
+}

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/Utils.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/Utils.java
@@ -1,0 +1,56 @@
+package com.epam.jdi.http;
+
+import com.epam.http.annotations.ServiceDomain;
+import com.epam.http.performance.PerformanceResult;
+import com.epam.http.requests.MethodData;
+import com.epam.http.requests.RestMethod;
+import com.epam.http.requests.RestMethodTypes;
+import com.epam.http.response.RestResponse;
+import io.restassured.http.ContentType;
+
+import java.util.HashMap;
+
+import static com.epam.http.ExceptionHandler.exception;
+import static com.epam.http.requests.RestMethodTypes.GET;
+
+
+public class Utils {
+    public static final ThreadLocal<IRestService> service = new ThreadLocal<>();
+    public static final ThreadLocal<String> domainUrl = new ThreadLocal<>();
+    public static final ThreadLocal<PerformanceResult> performanceResult = new ThreadLocal<>();
+    public static final ThreadLocal<RestResponse> restResponse = new ThreadLocal<>();
+    public static final ThreadLocal<ContentType> requestContentType = new ThreadLocal<>();
+    public static final ThreadLocal<HashMap<String, String>> preparedHeader = new ThreadLocal<>();
+
+    public static RestMethod getRestMethod(String restMethodType) {
+        MethodData mtData = getMethodData(restMethodType);
+        String url = getUrlFromDomain(domainUrl.get(), mtData.getUrl(), restMethodType);
+        return new RestMethod(mtData.getType(), url);
+    }
+
+    private static MethodData getMethodData(String type) {
+        for (RestMethodTypes methodType : RestMethodTypes.values()) {
+            if(type.equalsIgnoreCase(methodType.name()))
+                return new MethodData(type.toLowerCase(), methodType);
+        }
+        return new MethodData(null, GET);
+    }
+    private static String getUrlFromDomain(String domain, String uri, String methodName) {
+        if (uri == null)
+            return null;
+        if (uri.contains("://"))
+            return uri;
+        if (domain == null)
+            throw exception(
+            "Can't instantiate method '%s' for domain '%s'. " +
+                    "Domain undefined and method url not contains '://'",
+                    methodName, domain);
+        return domain.replaceAll("/*$", "") + "/" + uri.replaceAll("^/*", "");
+    }
+
+    public static <T> String getDomain(Class<T> c) {
+        return c.isAnnotationPresent(ServiceDomain.class)
+                ? c.getAnnotation(ServiceDomain.class).value()
+                : null;
+    }
+}

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/RequestStepsEN.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/RequestStepsEN.java
@@ -1,0 +1,79 @@
+package com.epam.jdi.http.stepdefs.en;
+
+import com.epam.http.requests.RestMethod;
+import cucumber.api.DataTable;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import io.restassured.http.ContentType;
+import org.testng.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.epam.commons.LinqUtils.first;
+import static com.epam.jdi.http.Utils.*;
+import static io.restassured.http.ContentType.values;
+
+public class RequestStepsEN {
+
+    @Then("^I verify that ([^\"]*) method is alive$")
+    public void theGetMethodIsAlive(String methodName){
+        RestMethod getMethod = getRestMethod(methodName);
+        Assert.assertTrue(getMethod.isAlive());
+    }
+
+    @When("^I do ([^\"]*) request$")
+    public void iCallMethod(String methodName){
+        RestMethod restMethod;
+        switch(methodName.toUpperCase()){
+            case "POST":
+                restMethod = service.get().getPostMethod();
+                break;
+            case "GET":
+                restMethod = service.get().getGetMethod();
+                break;
+            case "PUT":
+                restMethod = service.get().getPutMethod();
+                break;
+            case "DELETE":
+                restMethod = service.get().getDelete();
+                break;
+            case "PATCH":
+                restMethod = service.get().getPatch();
+                break;
+            case "STATUS":
+                restMethod = service.get().getStatus();
+                break;
+            default:
+                return;
+        }
+        if (preparedHeader.get() != null)
+        {
+            for (Map.Entry<String, String> entry : preparedHeader.get().entrySet()){
+                restMethod.addHeader(entry.getKey(), entry.getValue());
+            }
+        }
+        if (requestContentType.get() != null)
+            restMethod.setContentType(requestContentType.get());
+        restResponse.set(restMethod.call());
+    }
+
+    @Given("^I have the following headers:$")
+    public void iHaveTheFollowingHeaders(DataTable headers) {
+        preparedHeader.set(null);
+        HashMap<String, String> hashMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : headers.asMap(String.class, String.class).entrySet()){
+            hashMap.put(entry.getKey(), entry.getValue());
+        }
+        preparedHeader.set(hashMap);
+    }
+
+    @And("^I set ([^\"]*) request content type$")
+    public void iSetJSONRequestContentType(String type) {
+        ContentType contentType = first(values(),
+            ct -> type.equalsIgnoreCase(ct.name()));
+        requestContentType.set(contentType);
+    }
+}

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/RequestStepsEN.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/RequestStepsEN.java
@@ -12,8 +12,8 @@ import org.testng.Assert;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.epam.commons.LinqUtils.first;
 import static com.epam.jdi.http.Utils.*;
+import static com.epam.jdi.tools.LinqUtils.first;
 import static io.restassured.http.ContentType.values;
 
 public class RequestStepsEN {
@@ -21,7 +21,7 @@ public class RequestStepsEN {
     @Then("^I verify that ([^\"]*) method is alive$")
     public void theGetMethodIsAlive(String methodName){
         RestMethod getMethod = getRestMethod(methodName);
-        Assert.assertTrue(getMethod.isAlive());
+        getMethod.isAlive();
     }
 
     @When("^I do ([^\"]*) request$")

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ResponseStepsEN.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ResponseStepsEN.java
@@ -1,7 +1,7 @@
 package com.epam.jdi.http.stepdefs.en;
 
-import com.epam.commons.map.MapArray;
 import com.epam.http.response.ResponseStatusType;
+import com.epam.jdi.tools.map.MapArray;
 import cucumber.api.DataTable;
 import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ResponseStepsEN.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ResponseStepsEN.java
@@ -1,0 +1,88 @@
+package com.epam.jdi.http.stepdefs.en;
+
+import com.epam.commons.map.MapArray;
+import com.epam.http.response.ResponseStatusType;
+import cucumber.api.DataTable;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Then;
+import org.hamcrest.Matcher;
+import org.testng.Assert;
+
+import static com.epam.jdi.http.Utils.performanceResult;
+import static com.epam.jdi.http.Utils.restResponse;
+import static java.lang.String.format;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.testng.Assert.assertEquals;
+
+public class ResponseStepsEN {
+
+    @Then("^Performance results don't have any fails$")
+    public void performanceResultsDonTHaveAnyFails() {
+        Assert.assertTrue(performanceResult.get().NoFails());
+    }
+
+    @And("^I check number of requests$")
+    public void iCheckNumberOfRequests() {
+        System.out.println("There were " + performanceResult.get().NumberOfRequests + " requests.");
+    }
+
+    @Then("^Response status code equals (\\d+)$")
+    public void responseStatusCodeEquals(int statusCode){
+        assertEquals(restResponse.get().status.code, statusCode);
+    }
+
+    @And("^Response body is empty")
+    public void responseBodyIs() {
+        assertEquals(restResponse.get().body, "");
+    }
+
+    @And("^Response status type is ([^\"]*)$")
+    public void responseStatusTypeIs(String type) {
+        Boolean typeMatches = false;
+        for (ResponseStatusType responseStatusType : ResponseStatusType.values()) {
+            if(type.equalsIgnoreCase(responseStatusType.name()))
+                typeMatches = true;
+        }
+        Assert.assertTrue(typeMatches);
+    }
+
+    @And("^Response \"([^\"]*)\" is \"([^\"]*)\"$")
+    public void responseParameterIsValue(String parameter, String value) {
+        restResponse.get().assertThat().body(parameter, equalTo(value));
+    }
+    @And("^Response \"([^\"]*)\" contains \"([^\"]*)\"$")
+    public void responseParameterContainsValue(String parameter, String value) {
+        restResponse.get().assertThat().body(parameter, containsString(value));
+    }
+    @And("^Response body has values$")
+    public void responseBodyHasValues(DataTable params) {
+        MapArray<String, Matcher<?>> map =
+            new MapArray<>(params.raw(), p -> p.get(0), p -> equalTo(p.get(1)));
+        restResponse.get().assertBody(map);
+    }
+
+    @Then("^I check if performance results contain any fails$")
+    public void iCheckIfPerformanceResultsContainAnyFails() {
+        long numberOfFails = performanceResult.get().NumberOfFails;
+        Assert.assertEquals(numberOfFails, 0,
+                format("There were %s failures.", numberOfFails));
+    }
+
+    @And("^Average response time is lesser than (\\d+) sec$")
+    public void averageResponseTime(long seconds) {
+        long respTime = performanceResult.get().AverageResponseTime;
+        Assert.assertTrue(respTime < seconds*1000,
+                format("Average response time %s msec but expected not more than 2 sec", respTime));
+    }
+
+    @And("^Response header \"([^\"]*)\" is \"([^\"]*)\"$")
+    public void responseHeaderIs(String parameter, String value) {
+        restResponse.get().assertThat().header(parameter, value);
+    }
+
+    @And("^I print response$")
+    public void iPrintResponse() {
+        restResponse.get();
+    }
+}

--- a/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ServiceStepsEN.java
+++ b/jdi-dark-bdd/src/main/java/com/epam/jdi/http/stepdefs/en/ServiceStepsEN.java
@@ -1,0 +1,21 @@
+package com.epam.jdi.http.stepdefs.en;
+
+import com.epam.http.requests.RestMethod;
+import cucumber.api.java.en.When;
+
+import static com.epam.http.performance.RestLoad.loadService;
+import static com.epam.jdi.http.Utils.*;
+
+public class ServiceStepsEN {
+
+    @When("^I load service for (\\d+) sec with get requests$")
+    public void loadServiceForSecWithGetRequests(int seconds) {
+        RestMethod getMethod = service.get().getGetMethod();
+        performanceResult.set(loadService(seconds, getMethod));
+    }
+
+    @When("^I do status request with (\\d+) code$")
+    public void iCallStatusRequest(int status) {
+        restResponse.set(service.get().getStatus().call(String.valueOf(status)));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,5 +52,7 @@
     <modules>
         <module>jdi-dark</module>
         <module>jdi-dark-tests</module>
+        <module>jdi-dark-bdd</module>
+        <module>jdi-dark-bdd-tests</module>
     </modules>
 </project>


### PR DESCRIPTION
[#7](https://github.com/jdi-testing/jdi-dark/issues/7) - Move code for jdi-http-cucumber to jdi-dark repository