### PR TITLE
Header test are added, which consists of just 2 tests.

### DIFF
--- a/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
+++ b/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
@@ -1,9 +1,14 @@
 package com.epam.jdi.httptests;
 
+import com.epam.http.annotations.ContentType;
 import com.epam.http.annotations.GET;
+import com.epam.http.annotations.Header;
+import com.epam.http.annotations.Headers;
 import com.epam.http.annotations.POST;
 import com.epam.http.annotations.ServiceDomain;
 import com.epam.http.requests.RestMethod;
+
+import static io.restassured.http.ContentType.JSON;
 
 @ServiceDomain("http://localhost:8080/")
 public class JettyService {
@@ -22,4 +27,15 @@ public class JettyService {
 
     @GET("/setCommonIdCookies")
     static RestMethod getCommonIdCookies;
+
+    @GET("/header")
+    @Header(name = "HeaderTestName", value = "HeaderTestValue")
+    static RestMethod getWithSingleHeaderInRequest;
+
+    @GET("/header")
+    @Headers({
+            @Header(name = "Header1", value = "Value1"),
+            @Header(name = "Header2", value = "Value2")
+    })
+    static RestMethod getWithMultipleHeadersInRequest;
 }

--- a/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
+++ b/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
@@ -1,14 +1,11 @@
 package com.epam.jdi.httptests;
 
-import com.epam.http.annotations.ContentType;
 import com.epam.http.annotations.GET;
 import com.epam.http.annotations.Header;
 import com.epam.http.annotations.Headers;
 import com.epam.http.annotations.POST;
 import com.epam.http.annotations.ServiceDomain;
 import com.epam.http.requests.RestMethod;
-
-import static io.restassured.http.ContentType.JSON;
 
 @ServiceDomain("http://localhost:8080/")
 public class JettyService {

--- a/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
+++ b/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
@@ -1,0 +1,33 @@
+package com.epam.jdi.httptests;
+
+import com.epam.http.response.RestResponse;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static com.epam.http.requests.ServiceInit.init;
+import static com.epam.jdi.httptests.JettyService.getWithMultipleHeadersInRequest;
+import static com.epam.jdi.httptests.JettyService.getWithSingleHeaderInRequest;
+import static org.hamcrest.Matchers.containsString;
+
+public class HeaderTests {
+
+    @BeforeTest
+    public void before() {
+        init(JettyService.class);
+    }
+
+    @Test
+    public void singleHeaderIsAllowedInRequest() {
+        RestResponse response = getWithSingleHeaderInRequest.call();
+        response.isOk();
+        response.assertBody(new Object[][] {{"headers.Headertestname", containsString("HeaderTestValue")}});
+    }
+
+    @Test
+    public void multipleHeadersAreAllowedInRequest() {
+        RestResponse response = getWithMultipleHeadersInRequest.call();
+        response.isOk();
+        response.assertBody(new Object[][]{{"headers.Header1", containsString("Value1")},
+                {"headers.Header2", containsString("Value2")}});
+    }
+}


### PR DESCRIPTION
All other checks are done in restassured and can onlu be done by
restassured methods.
Please refer to Jdi-dark missing capabilities doc.