### PR TITLE
109_catch_errors_by_rest_assured

### DIFF
--- a/jdi-dark/src/main/java/com/epam/http/requests/RestRequest.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/RestRequest.java
@@ -5,7 +5,6 @@ import com.epam.http.response.RestResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 
-import static com.epam.http.ExceptionHandler.exception;
 import static com.epam.http.JdiHttpSettigns.verifyOkStatus;
 import static java.lang.System.currentTimeMillis;
 
@@ -25,11 +24,9 @@ public class RestRequest {
             RestMethodTypes methodType, RequestSpecification spec, ResponseStatusType expectedStatus) {
         Response response;
         long time;
-        try {
-            time = currentTimeMillis();
-            response = methodType.method.apply(spec);
-            time = currentTimeMillis() - time;
-        } catch (Exception ex) { throw exception("Request failed"); }
+        time = currentTimeMillis();
+        response = methodType.method.apply(spec);
+        time = currentTimeMillis() - time;
         RestResponse resp = new RestResponse(response, time);
         if (verifyOkStatus)
             resp.isStatus(expectedStatus);


### PR DESCRIPTION
Catch errors by rest ussured while there isn't  event handler for different options

https://github.com/jdi-testing/jdi-dark/issues/109   - resolve point 4 RestResponse doRequest do not throw full stack trace