### PR TITLE
128_HeadersRework

### DIFF
--- a/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
+++ b/jdi-dark-tests/src/main/java/com/epam/jdi/httptests/JettyService.java
@@ -42,6 +42,9 @@ public class JettyService {
     @GET("/multiValueHeader")
     public static RestMethod getMultiValueHeader;
 
+    @GET("/multiHeaderReflect")
+    public static RestMethod getMultiHeaderReflect;
+
     @DELETE("/cookie")
     public static RestMethod deleteCookie;
 

--- a/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
+++ b/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
@@ -15,8 +15,11 @@ import static com.epam.jdi.httptests.JettyService.getMultiHeaderReflect;
 import static com.epam.jdi.httptests.JettyService.getLotto;
 import static com.epam.jdi.httptests.JettyService.getHeader;
 import static io.restassured.RestAssured.requestSpecification;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class HeaderTests extends WithJetty {
@@ -48,18 +51,6 @@ public class HeaderTests extends WithJetty {
                 .and().assertThat().body(containsString("SecondHeader"));
     }
 
-    @Test
-    public void requestDataAllowsSpecifyingMultipleHeaders84728736482() {
-        RestResponse response = getMultiHeaderReflect.call(
-                requestData(requestData ->
-                        requestData.headers = new JDIHeaders(new String[][]
-                                {{"MyHeader", "MyValue"}, {"SecondHeader", "MyValue2"},
-                                        {"MultiValueHeader", "MyValue3", "MyValue4", "MyValue5"}
-
-                        })));
-        response.isOk();
-        response.headers();
-    }
 
     @Test
     public void allowsSupplyingMappingFunction() {
@@ -118,26 +109,17 @@ public class HeaderTests extends WithJetty {
     }
 
     @Test
-    public void multiHeadersPrototype() {
-        RestResponse response = getMultiHeaderReflect.call(
-                requestData(requestData ->
-                        requestData.headers = new JDIHeaders(new String[][]{
-                                {"MyHeader", "TestValue"}, {"SecondHeader", "SecondHeaderTestValue"}
-                        })));
-        response.isOk();
-        response.headers();
-    }
-
-    @Test
-    public void multiHeadersPrototype2() {
+    public void multiValueTestExample() {
         Header header1 = new Header("MyHeader1", "MyValue1");
         Header header2 = new Header("MyHeader2", "MyValue2");
-        Header header3 = new Header("MyHeader2", "MyValue3");
+        Header header3 = new Header("MyHeader2", "MyValue23");
         RestResponse response = getMultiHeaderReflect.call(
                 requestData(requestData ->
                         requestData.headers = new JDIHeaders(header1, header2, header3)));
         response.isOk();
-        response.headers();
+        response.assertThat().header("MyHeader1", containsString("MyValue1"));
+        assertThat(response.headers().getValues("MyHeader2").size(), is(2));
+        assertThat(response.headers().getValues("MyHeader2"), hasItems("MyValue2", "MyValue23"));
     }
 
 }

--- a/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
+++ b/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/HeaderTests.java
@@ -121,5 +121,4 @@ public class HeaderTests extends WithJetty {
         assertThat(response.headers().getValues("MyHeader2").size(), is(2));
         assertThat(response.headers().getValues("MyHeader2"), hasItems("MyValue2", "MyValue23"));
     }
-
 }

--- a/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/PostmanAuthTests.java
+++ b/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/PostmanAuthTests.java
@@ -1,5 +1,6 @@
 package com.epam.jdi.httptests;
 
+import com.epam.http.requests.components.JDIHeaders;
 import com.epam.http.response.RestResponse;
 import com.epam.jdi.tools.map.MultiMap;
 import com.wealdtech.hawk.Hawk;
@@ -81,7 +82,7 @@ public class PostmanAuthTests {
     @Test
     public void authDigestFailTest() {
         RestResponse resp = authDigest.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "Digest username=\"postman\", realm=\"Users\", nonce=\"ni1LiL0O37PRRhofWdCLmwFsnEtH1lew\", uri=\"/digest-auth\", response=\"254679099562cf07df9b6f5d8d15db45\", opaque=\"\""}
                 })));
         resp.assertThat()
@@ -99,7 +100,7 @@ public class PostmanAuthTests {
         long ts = timestamp.getTime() / 1000;
         String mac = calculateMAC(hawkCredentials, Hawk.AuthType.HEADER, ts, uri, "x9Feni", "GET", null, null, null, null);
         RestResponse resp = authHawk.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "Hawk id=\"dh37fgj492je\", ts=\"" + ts + "\", nonce=\"x9Feni\", mac=\"" + mac + "\""}
                 })));
         resp.isOk().assertThat()
@@ -117,7 +118,7 @@ public class PostmanAuthTests {
         long ts = 1234567890;
         String mac = calculateMAC(hawkCredentials, Hawk.AuthType.HEADER, ts, uri, "x9Feni", "GET", null, null, null, null);
         RestResponse resp = authHawk.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "Hawk id=\"dh37fgj492je\", ts=\"" + ts + "\", nonce=\"x9Feni\", mac=\"" + mac + "\""}
                 })));
         resp.assertThat()
@@ -137,7 +138,7 @@ public class PostmanAuthTests {
         body.put("message", "Bad mac");
         body.put("attributes", attr);
         RestResponse resp = authHawk.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "Hawk id=\"dh37fgj492je\", ts=\"ts\", nonce=\"x9Feni\", mac=\"mac\""}
                 })));
         resp.assertThat()
@@ -150,7 +151,7 @@ public class PostmanAuthTests {
         String key = "RKCGzna7bv9YD57c";
         String nonce = "R6MyHe5WCRx";
         RestResponse resp = oauth.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "OAuth oauth_consumer_key=\"" + key + "\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1580379117\", oauth_nonce=\"" + nonce + "\", oauth_version=\"1.0\", oauth_signature=\"hzZRrfQkn4ux9qSbmDJFPKj3P8w%3D\""}
                 })));
         resp.isOk().assertThat()
@@ -164,7 +165,7 @@ public class PostmanAuthTests {
         String key = "RKCGzna7bv9YD57";
         String nonce = "R6MyHe5WCRx";
         RestResponse resp = oauth.call(requestData(rd ->
-                rd.headers = new MultiMap<>(new Object[][]{
+                rd.headers = new JDIHeaders(new String[][]{
                         {"Authorization", "OAuth oauth_consumer_key=\"" + key + "\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1580379117\", oauth_nonce=\"" + nonce + "\", oauth_version=\"1.0\", oauth_signature=\"hzZRrfQkn4ux9qSbmDJFPKj3P8w%3D\""}
                 })));
         resp.assertThat()

--- a/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/ServiceTest.java
+++ b/jdi-dark-tests/src/test/java/com/epam/jdi/httptests/ServiceTest.java
@@ -1,5 +1,6 @@
 package com.epam.jdi.httptests;
 
+import com.epam.http.requests.components.JDIHeaders;
 import com.epam.http.response.RestResponse;
 import com.epam.jdi.tools.map.MultiMap;
 import io.qameta.allure.restassured.AllureRestAssured;
@@ -46,7 +47,7 @@ public class ServiceTest {
         RestResponse resp = GET(requestData(
                 rd -> {
                     rd.uri = "https://httpbin.org/get";
-                    rd.headers = new MultiMap<>(new Object[][]{
+                    rd.headers = new JDIHeaders(new String[][]{
                             {"Name", "Roman"},
                             {"Id", "TestTest"}
                     });

--- a/jdi-dark/src/main/java/com/epam/http/requests/RequestData.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/RequestData.java
@@ -1,9 +1,13 @@
 package com.epam.http.requests;
 
+import com.epam.http.requests.components.JDIHeaders;
 import com.epam.jdi.tools.DataClass;
 import com.epam.jdi.tools.func.JAction1;
 import com.epam.jdi.tools.map.MultiMap;
 import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+
+import java.util.ArrayList;
 
 /**
  * Represents all HTTP request data.
@@ -16,7 +20,7 @@ public class RequestData extends DataClass<RequestData> {
     public String path = null;
     public String body = null;
     public ContentType contentType = null;
-    public MultiMap<String, String> headers = new MultiMap<>();
+    public JDIHeaders headers = new JDIHeaders();
     public MultiMap<String, String> pathParams = new MultiMap<>();
     public MultiMap<String, String> queryParams = new MultiMap<>();
     public MultiMap<String, String> cookies = new MultiMap<>();

--- a/jdi-dark/src/main/java/com/epam/http/requests/RequestData.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/RequestData.java
@@ -16,9 +16,6 @@ import java.util.List;
 import java.util.Map;
 import io.restassured.specification.MultiPartSpecification;
 import java.io.File;
-import io.restassured.http.Header;
-
-import java.util.ArrayList;
 
 /**
  * Represents all HTTP request data.

--- a/jdi-dark/src/main/java/com/epam/http/requests/RestMethod.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/RestMethod.java
@@ -373,7 +373,7 @@ public class RestMethod<T> {
             spec.body(data.body);
         }
         if (data.headers.any()) {
-            spec.headers(data.headers.toMap());
+            spec.headers(data.headers.asRaHeaders());
         }
         if (data.cookies.any()) {
             spec.cookies(data.cookies.toMap());

--- a/jdi-dark/src/main/java/com/epam/http/requests/components/JDIHeaders.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/components/JDIHeaders.java
@@ -8,6 +8,11 @@ import java.util.List;
 
 import static io.restassured.internal.common.assertion.AssertParameter.notNull;
 
+/**
+ * This class is created to allow adding/removing headers of the fly
+ * This is basically a wrapper around ArrayList
+ */
+
 public class JDIHeaders {
 
     private ArrayList<Header> headers;
@@ -21,6 +26,15 @@ public class JDIHeaders {
         this.headers = new ArrayList<>(headers);
     }
 
+    /**
+     * This method is a mere example how one can use this class.
+     * In this case the following method allows to build headers out
+     * of a string array object like this:
+     *  JDIHeader headers = new JDIHeader(
+     *      new String[][] {{"Header_01", "Value_01"}, {"Header_02", "Value_02"},
+     *      {"MultiValuesHeader", "multiValue_01", "multiValue_02", "multiValue_03}});
+     * @param listOfHeaderStrings
+     */
     public JDIHeaders(String[][] listOfHeaderStrings) {
         this.headers = new ArrayList<>();
         for (String[] headerArray: listOfHeaderStrings) {
@@ -39,18 +53,34 @@ public class JDIHeaders {
         }
     }
 
+    /**
+     * Checks if header's list is empty
+     * @return boolean
+     */
     public boolean isEmpty() {
         return this.headers.size() == 0;
     }
 
+    /**
+     * Add a header in the list using RestAssured Header object
+     * @return boolean
+     */
     public boolean add(Header header) {
         return this.headers.add(header);
     }
 
+    /**
+     * Add a header in the list using headers Name and Value strings
+     * @return boolean
+     */
     public boolean add(String name, String value) {
         return this.headers.add(new Header(name, value));
     }
 
+    /**
+     * Adds to headers all headers from given List of RestAssured Header objects
+     * @return boolean
+     */
     public boolean addAll(ArrayList<Header> headers) {
         for (Header header : headers)
             if (!add(header))
@@ -58,6 +88,10 @@ public class JDIHeaders {
         return true;
     }
 
+    /**
+     * Adds to headers all headers from given JDIHeaders object
+     * @return boolean
+     */
     public boolean addAll(JDIHeaders headers) {
         for (Header header : headers.asList())
             if (!add(header))
@@ -65,23 +99,44 @@ public class JDIHeaders {
         return true;
     }
 
+    /**
+     * Gives access to inner ArrayList for direct usage
+     * @return ArrayList<Header>
+     */
     public ArrayList<Header> asList() {
         return this.headers;
     }
 
+    /**
+     * Returns array size
+     * @return int
+     */
     public int size() {
         return this.headers.size();
     }
 
+    /**
+     * Returns headers as RestAssured Headers object,
+     * which may be handy for some advanced RestAssured shenanigans
+     * @return Headers
+     */
     public Headers asRaHeaders() {
         Headers raHeaders = new Headers(this.headers);
         return raHeaders;
     }
 
+    /**
+     * Clears the list of headers
+     * @return void
+     */
     public void clear() {
         this.headers.clear();
     }
 
+    /**
+     * Returns True if list size is bigger than 0;
+     * @return boolean
+     */
     public boolean any() {
         return this.size() > 0;
     }

--- a/jdi-dark/src/main/java/com/epam/http/requests/components/JDIHeaders.java
+++ b/jdi-dark/src/main/java/com/epam/http/requests/components/JDIHeaders.java
@@ -1,0 +1,89 @@
+package com.epam.http.requests.components;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.restassured.internal.common.assertion.AssertParameter.notNull;
+
+public class JDIHeaders {
+
+    private ArrayList<Header> headers;
+
+    public JDIHeaders(Header... headers) {
+        this(Arrays.asList(headers));
+    }
+
+    public JDIHeaders(List<Header> headers) {
+        notNull(headers, "Headers");
+        this.headers = new ArrayList<>(headers);
+    }
+
+    public JDIHeaders(String[][] listOfHeaderStrings) {
+        this.headers = new ArrayList<>();
+        for (String[] headerArray: listOfHeaderStrings) {
+            if (headerArray.length < 2) {
+                throw new IllegalArgumentException("Not sufficient arguments to determine Name and Value for a header");
+            }
+            else if (headerArray.length == 2) {
+                this.headers.add(new Header(headerArray[0], headerArray[1]));
+            }
+            else {
+                String name = headerArray[0];
+                String[] valuesArray = Arrays.copyOfRange(headerArray, 1, headerArray.length);
+                String value = String.join(",", valuesArray);
+                this.headers.add(new Header(name, value));
+            }
+        }
+    }
+
+    public boolean isEmpty() {
+        return this.headers.size() == 0;
+    }
+
+    public boolean add(Header header) {
+        return this.headers.add(header);
+    }
+
+    public boolean add(String name, String value) {
+        return this.headers.add(new Header(name, value));
+    }
+
+    public boolean addAll(ArrayList<Header> headers) {
+        for (Header header : headers)
+            if (!add(header))
+                return false;
+        return true;
+    }
+
+    public boolean addAll(JDIHeaders headers) {
+        for (Header header : headers.asList())
+            if (!add(header))
+                return false;
+        return true;
+    }
+
+    public ArrayList<Header> asList() {
+        return this.headers;
+    }
+
+    public int size() {
+        return this.headers.size();
+    }
+
+    public Headers asRaHeaders() {
+        Headers raHeaders = new Headers(this.headers);
+        return raHeaders;
+    }
+
+    public void clear() {
+        this.headers.clear();
+    }
+
+    public boolean any() {
+        return this.size() > 0;
+    }
+}
+

--- a/jdi-dark/src/main/java/com/epam/http/response/RestResponse.java
+++ b/jdi-dark/src/main/java/com/epam/http/response/RestResponse.java
@@ -4,6 +4,7 @@ import com.epam.jdi.tools.func.JAction1;
 import com.epam.jdi.tools.map.MapArray;
 import com.epam.jdi.tools.pairs.Pair;
 import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Matcher;
@@ -146,12 +147,21 @@ public class RestResponse {
     }
 
     /**
-     * Get response headers.
+     * Get response headers as list.
      *
      * @return response headers list
      */
-    public List<Header> headers() {
+    public List<Header> headersAsList() {
         return raResponse.getHeaders().asList();
+    }
+
+    /**
+     * Get response headers as list.
+     *
+     * @return response headers list
+     */
+    public Headers headers() {
+        return raResponse.getHeaders();
     }
 
     /**


### PR DESCRIPTION
Headers rework. Implemented JDI headers class to allow the same capabilities as RestAssured: 
multi-value headers, same name headers;
Changed headers method to return directly Headers object instead of List.
